### PR TITLE
Rebuild gem naming conventions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,7 +52,7 @@ AllCops:
     - 'vendor/**/*'
     - '.git/**/*'
     - 'Gemfile'
-    - 'slack-msgr.gemspec'
+    - 'slack_msgr.gemspec'
     - 'spec/**/*'
     - Rakefile
     - bin/**
@@ -83,7 +83,7 @@ Naming/FileName:
   Enabled: true
   # Camel case file names listed in `AllCops:Include` and all file names listed
   # in `AllCops:Exclude` are excluded by default. Add extra excludes here.
-  Exclude: [slack-msgr.gemspec]
+  Exclude: [slack_msgr.gemspec]
   # When `true`, requires that each source file should define a class or module
   # with a name which matches the file name (converted to ... case).
   # It further expects it to be nested inside modules which match the names

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in slack-msgr.gemspec
+# Specify your gem's dependencies in slack_msgr.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    slack_msgr (0.0.1)
+    slack_msgr (0.0.2)
       faraday (~> 0.15.4)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    slack-msgr (0.0.1)
+    slack_msgr (0.0.1)
       faraday (~> 0.15.4)
 
 GEM
@@ -90,7 +90,7 @@ DEPENDENCIES
   rspec (~> 3.0)
   rubocop (~> 0.71.0)
   simplecov
-  slack-msgr!
+  slack_msgr!
 
 BUNDLED WITH
    2.0.2

--- a/lib/config/constants.rb
+++ b/lib/config/constants.rb
@@ -5,5 +5,5 @@ module SlackMsgr
 
   SLACK_URL = 'https://slack.com'
 
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/lib/config/initializer.rb
+++ b/lib/config/initializer.rb
@@ -4,4 +4,9 @@ require 'json'
 require 'faraday'
 require_relative './constants'
 
-Dir[File.expand_path 'lib/{slack_msgr,utils}/**/*.rb'].each { |f| require f }
+path = __dir__
+
+require "#{path}/../slack_msgr/fetcher"
+require "#{path}/../slack_msgr/chat"
+require "#{path}/../slack_msgr/configuration"
+require "#{path}/../utils/error_handling"

--- a/slack_msgr.gemspec
+++ b/slack_msgr.gemspec
@@ -1,10 +1,9 @@
-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require './lib/config/constants'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'slack-msgr'
+  spec.name          = 'slack_msgr'
   spec.version       = SlackMsgr::VERSION
   spec.authors       = ['Ryan Workman']
   spec.email         = ['rdavid1099@gmail.com']
@@ -16,7 +15,7 @@ Gem::Specification.new do |spec|
 
   if spec.respond_to?(:metadata)
     spec.metadata['homepage_uri'] = spec.homepage
-    spec.metadata['source_code_uri'] = 'https://github.com/rdavid1099/slack-msgr'
+    spec.metadata['source_code_uri'] = 'https://github.com/rdavid1099/slack_msgr'
   else
     raise 'RubyGems 2.0 or newer is required to protect against ' \
       'public gem pushes.'

--- a/spec/unit/slack_msgr_spec.rb
+++ b/spec/unit/slack_msgr_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe SlackMsgr do
-  it 'has a version number of 0.0.1' do
-    expect(SlackMsgr::VERSION).to eq('0.0.1')
+  it 'has a version number of 0.0.2' do
+    expect(SlackMsgr::VERSION).to eq('0.0.2')
   end
 end


### PR DESCRIPTION
Change version `0.0.2`.
File naming changed to remain consistent with gem and ruby conventions
Fixed issue with file requiring when gem is a self-contained package