### PR TITLE
Add users.admin.invite and legacy_token support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    slack_msgr (0.0.3)
+    slack_msgr (0.0.5)
       faraday (~> 0.15.4)
 
 GEM

--- a/lib/config/constants.rb
+++ b/lib/config/constants.rb
@@ -5,5 +5,5 @@ module SlackMsgr
 
   SLACK_URL = 'https://slack.com'
 
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end

--- a/lib/config/initializer.rb
+++ b/lib/config/initializer.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'faraday'
+require 'uri'
 require_relative './constants'
 
 path = __dir__
@@ -9,4 +10,5 @@ path = __dir__
 require "#{path}/../slack_msgr/slack_method"
 require "#{path}/../slack_msgr/chat"
 require "#{path}/../slack_msgr/configuration"
+require "#{path}/../slack_msgr/users"
 require "#{path}/../utils/error_handling"

--- a/lib/slack_msgr.rb
+++ b/lib/slack_msgr.rb
@@ -11,10 +11,15 @@ module SlackMsgr
 
     def configure
       yield(configuration)
+      nil
     end
 
     def chat(method, opts = {})
       Chat.call(method, opts)
+    end
+
+    def users(*methods, **opts)
+      Users.call(methods, opts)
     end
   end
 end

--- a/lib/slack_msgr/configuration.rb
+++ b/lib/slack_msgr/configuration.rb
@@ -6,6 +6,7 @@ module SlackMsgr
     attr_accessor :verification_token,
                   :client_secret,
                   :signing_secret,
+                  :legacy_token,
                   :access_tokens,
                   :set_default_token
 
@@ -13,12 +14,14 @@ module SlackMsgr
       verification_token: nil,
       client_secret: nil,
       signing_secret: nil,
+      legacy_token: nil,
       access_tokens: {},
       set_default_token: nil
     )
       @verification_token = verification_token
       @client_secret      = client_secret
       @signing_secret     = signing_secret
+      @legacy_token       = legacy_token
       @access_tokens      = access_tokens
       @set_default_token  = set_default_token
     end
@@ -27,6 +30,7 @@ module SlackMsgr
       @verification_token = nil
       @client_secret      = nil
       @signing_secret     = nil
+      @legacy_token       = nil
       @access_tokens      = {}
       @set_default_token  = nil
       @default_token      = nil

--- a/lib/slack_msgr/users.rb
+++ b/lib/slack_msgr/users.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module SlackMsgr
+  # Handles all users functionality and methods corresponding with Slack API
+  class Users < SlackMethod
+    USERS_METHODS = {
+      admin: 'admin',
+      invite: 'invite'
+    }.freeze
+
+    REQUIRED_ARGUMENTS = %i[email].freeze
+
+    PERMITTED_ARGUMENTS = %i[
+      token
+      email
+      channels
+      real_name
+      resend
+      restricted
+      ultra_restricted
+      expiration_ts
+    ].freeze
+
+    class << self
+      def call(method, opts = {})
+        users = new(method, opts)
+        send_legacy_request_to_slack(users)
+      end
+    end
+
+    attr_reader :method,
+                :opts,
+                :body
+
+    def initialize(methods, opts)
+      users_method = methods.map do |method|
+        ErrorHandling.raise(:unknown_method, method: method) unless USERS_METHODS[method]
+
+        USERS_METHODS[method]
+      end.join(".")
+
+      @method = "users.#{users_method}"
+      @opts   = opts
+      @body   = sanitize_body
+      puts body
+    end
+
+    private
+
+    def sanitize_body
+      ErrorHandling.raise(:req_args_missing, req_args: REQUIRED_ARGUMENTS, method: method) if req_args_missing? # rubocop:disable LineLength
+      puts opts.merge(token)
+      opts.merge!(token).keys.each_with_object({}) do |key, body|
+        body[key] ||= opts[key] if PERMITTED_ARGUMENTS.include?(key)
+        body
+      end
+    end
+
+    def req_args_missing?
+      !(REQUIRED_ARGUMENTS - opts.keys).empty?
+    end
+
+    def token
+      {token: SlackMsgr.configuration.legacy_token}
+    end
+  end
+end

--- a/spec/unit/slack_msgr_spec.rb
+++ b/spec/unit/slack_msgr_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe SlackMsgr do
-  it 'has a version number of 0.0.4' do
-    expect(SlackMsgr::VERSION).to eq('0.0.4')
+  it 'has a version number of 0.0.5' do
+    expect(SlackMsgr::VERSION).to eq('0.0.5')
   end
 end


### PR DESCRIPTION
Add the undocumented functionality to invite new users to a workspace (https://github.com/ErikKalkoken/slackApiDoc/blob/master/users.admin.invite.md).

This also adds support for legacy tokens and introduces the `SlackMsgr#users` method.